### PR TITLE
Remove row assumption

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function connect(settings) {
     raw(sql, options = {}) {
       const dbApi = options.dbApi || knex;
       return dbApi.raw(sql, options)
-        .then(res => res && res.rows ? res.rows : res);
+        .then(res => res.rows || res);
     }
   };
 }

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function connect(settings) {
     raw(sql, options = {}) {
       const dbApi = options.dbApi || knex;
       return dbApi.raw(sql, options)
-        .then(res => res.rows);
+        .then(res => res && res.rows ? res.rows : res);
     }
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "breadfruit",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Boilerplate sql query system for Node.js using Knex",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "breadfruit",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Boilerplate sql query system for Node.js using Knex",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# WHAT IT DOES 
Removes dependency on the `rows` optimization we are using which is more of a _postgres_ faculty

# WHAT IT SOLVES
When using knex with MsSQL, Transact-SQL, or SQL Server syntax, knex does not return the rows item.  If the rows do not exist this aims to actively just return back all data received from the server.

# EXTRA
It presents no breaking changes, and this is also more of a bug, so a patch and putsh is why I bumped the version this way.