### PR TITLE
chore: Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "url": "git+ssh://git@github.com/iceddev/breadfruit.git"
   },
   "dependencies": {
-    "knex": "^0.21.5"
+    "knex": "^2.3.0"
   },
   "devDependencies": {
-    "chai": "^4.2.0",
-    "mocha": "^8.1.3",
+    "chai": "^4.3.7",
+    "mocha": "^10.2.0",
     "nyc": "^15.1.0"
   }
 }


### PR DESCRIPTION
This aligns the knex version between this dependency and hls's members_app.

I was a little surprised to learn that knex seems to have an open SQL vulnerability, even in its newest version.
https://github.com/advisories/GHSA-4jv9-3563-23j3